### PR TITLE
Fix duplicate os import

### DIFF
--- a/task24/handlers.py
+++ b/task24/handlers.py
@@ -11,7 +11,6 @@ from core import states
 from core import utils as core_utils
 from .checker import PlanBotData, evaluate_plan, FEEDBACK_KB
 from . import keyboards
-import os
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- remove redundant os import in task24/handlers

## Testing
- `pytest -q` *(fails: NameError in task19/evaluator)*

------
https://chatgpt.com/codex/tasks/task_e_6844857b131083319afa60b085b2bf4e