### PR TITLE
Fix imports in evaluator

### DIFF
--- a/task19/evaluator.py
+++ b/task19/evaluator.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional
+from typing import List, Optional, Dict, Any
 from dataclasses import dataclass
 
 # Исправленный импорт базовых классов оценщика


### PR DESCRIPTION
## Summary
- extend typing imports in `task19/evaluator.py`

## Testing
- `pytest -q` *(fails: fancycompleter has no LazyVersion)*

------
https://chatgpt.com/codex/tasks/task_e_6844857cd8d88331b30396291e6aef6e