### PR TITLE
Setup logger in ai_config

### DIFF
--- a/core/ai_config.py
+++ b/core/ai_config.py
@@ -3,9 +3,12 @@
 """
 
 import os
+import logging
 from dataclasses import dataclass
 from typing import Dict, Any, Optional
 from enum import Enum
+
+logger = logging.getLogger(__name__)
 
 
 class TaskType(Enum):


### PR DESCRIPTION
## Summary
- add global logger to `core/ai_config.py`
- ensure functions in the module use that logger

## Testing
- `pytest -q` *(fails: module 'fancycompleter' has no attribute 'LazyVersion')*

------
https://chatgpt.com/codex/tasks/task_e_6844857baca083318b02e4eb64f0f5cd