### PR TITLE
Fix ai service context usage

### DIFF
--- a/core/ai_evaluator.py
+++ b/core/ai_evaluator.py
@@ -169,43 +169,43 @@ class Task19Evaluator(BaseAIEvaluator):
     "suggestions": ["список рекомендаций"]
 }}"""
 
-        result = await self.ai_service.get_json_completion(
-            evaluation_prompt,
-            system_prompt=self.get_system_prompt(),
-            temperature=0.2
-        )
-        
-        if not result:
-            # Fallback оценка
-            return EvaluationResult(
-                scores={"К1": 1},
-                total_score=1,
-                max_score=3,
-                feedback="Не удалось полностью проверить ответ. Требуется проверка преподавателем.",
-                detailed_analysis={},
-                suggestions=[],
-                factual_errors=[]
+        async with self.ai_service:
+            result = await self.ai_service.get_json_completion(
+                evaluation_prompt,
+                system_prompt=self.get_system_prompt(),
+                temperature=0.2
             )
-        
-        # Проверка фактических ошибок
-        factual_errors = await self.check_factual_accuracy(answer, topic)
-        
-        # Генерация обратной связи
-        feedback = await self.generate_feedback(
-            answer,
-            {"К1": result.get("score", 0)},
-            result.get("main_issues", [])
-        )
-        
-        return EvaluationResult(
-            scores={"К1": result.get("score", 0)},
-            total_score=result.get("score", 0),
-            max_score=3,
-            feedback=feedback,
-            detailed_analysis=result,
-            suggestions=result.get("suggestions", []),
-            factual_errors=factual_errors
-        )
+
+            if not result:
+                # Fallback оценка
+                return EvaluationResult(
+                    scores={"К1": 1},
+                    total_score=1,
+                    max_score=3,
+                    feedback="Не удалось полностью проверить ответ. Требуется проверка преподавателем.",
+                    detailed_analysis={},
+                    suggestions=[],
+                    factual_errors=[]
+                )
+
+            # Проверка фактических ошибок
+            factual_errors = await self.check_factual_accuracy(answer, topic)
+
+            # Генерация обратной связи
+            feedback = await self.generate_feedback(
+                answer,
+                {"К1": result.get("score", 0)},
+                result.get("main_issues", [])
+            )
+            return EvaluationResult(
+                scores={"К1": result.get("score", 0)},
+                total_score=result.get("score", 0),
+                max_score=3,
+                feedback=feedback,
+                detailed_analysis=result,
+                suggestions=result.get("suggestions", []),
+                factual_errors=factual_errors
+            )
 
 
 # Задание 20: Формулирование суждений
@@ -264,31 +264,32 @@ class Task20Evaluator(BaseAIEvaluator):
     "suggestions": ["рекомендации"]
 }}"""
 
-        result = await self.ai_service.get_json_completion(
-            evaluation_prompt,
-            system_prompt=self.get_system_prompt(),
-            temperature=0.2
-        )
-        
-        if not result:
-            return self._get_fallback_result()
-        
-        factual_errors = await self.check_factual_accuracy(answer, topic)
-        feedback = await self.generate_feedback(
-            answer,
-            {"К1": result.get("score", 0)},
-            result.get("main_issues", [])
-        )
-        
-        return EvaluationResult(
-            scores={"К1": result.get("score", 0)},
-            total_score=result.get("score", 0),
-            max_score=3,
-            feedback=feedback,
-            detailed_analysis=result,
-            suggestions=result.get("suggestions", []),
-            factual_errors=factual_errors
-        )
+        async with self.ai_service:
+            result = await self.ai_service.get_json_completion(
+                evaluation_prompt,
+                system_prompt=self.get_system_prompt(),
+                temperature=0.2
+            )
+
+            if not result:
+                return self._get_fallback_result()
+
+            factual_errors = await self.check_factual_accuracy(answer, topic)
+            feedback = await self.generate_feedback(
+                answer,
+                {"К1": result.get("score", 0)},
+                result.get("main_issues", [])
+            )
+
+            return EvaluationResult(
+                scores={"К1": result.get("score", 0)},
+                total_score=result.get("score", 0),
+                max_score=3,
+                feedback=feedback,
+                detailed_analysis=result,
+                suggestions=result.get("suggestions", []),
+                factual_errors=factual_errors
+            )
     
     def _get_fallback_result(self) -> EvaluationResult:
         return EvaluationResult(
@@ -382,32 +383,33 @@ class Task25Evaluator(BaseAIEvaluator):
     "suggestions": ["рекомендации"]
 }}"""
 
-        result = await self.ai_service.get_json_completion(
-            evaluation_prompt,
-            system_prompt=self.get_system_prompt(),
-            temperature=0.2
-        )
-        
-        if not result:
-            return self._get_fallback_result()
-        
-        scores = {
-            "К1": result.get("k1_score", 0),
-            "К2": result.get("k2_score", 0)
-        }
-        
-        factual_errors = await self.check_factual_accuracy(answer, topic)
-        feedback = await self.generate_feedback(answer, scores, result.get("main_issues", []))
-        
-        return EvaluationResult(
-            scores=scores,
-            total_score=result.get("total_score", 0),
-            max_score=6,
-            feedback=feedback,
-            detailed_analysis=result,
-            suggestions=result.get("suggestions", []),
-            factual_errors=factual_errors
-        )
+        async with self.ai_service:
+            result = await self.ai_service.get_json_completion(
+                evaluation_prompt,
+                system_prompt=self.get_system_prompt(),
+                temperature=0.2
+            )
+
+            if not result:
+                return self._get_fallback_result()
+
+            scores = {
+                "К1": result.get("k1_score", 0),
+                "К2": result.get("k2_score", 0)
+            }
+
+            factual_errors = await self.check_factual_accuracy(answer, topic)
+            feedback = await self.generate_feedback(answer, scores, result.get("main_issues", []))
+
+            return EvaluationResult(
+                scores=scores,
+                total_score=result.get("total_score", 0),
+                max_score=6,
+                feedback=feedback,
+                detailed_analysis=result,
+                suggestions=result.get("suggestions", []),
+                factual_errors=factual_errors
+            )
     
     def _get_fallback_result(self) -> EvaluationResult:
         return EvaluationResult(

--- a/task19/evaluator.py
+++ b/task19/evaluator.py
@@ -155,35 +155,36 @@ class Task19AIEvaluator(BaseAIEvaluator):
     "suggestions": ["конкретные рекомендации"]
 }}"""
 
-        result = await self.ai_service.get_json_completion(
-            evaluation_prompt,
-            system_prompt=self.get_system_prompt(),
-            temperature=0.2
-        )
-        
-        if not result:
-            return self._get_fallback_result(answer, topic)
-        
-        # Определение финального балла с учётом правил ЕГЭ 2025
-        score = self._calculate_final_score(result)
-        
-        # Проверка фактических ошибок
-        factual_errors = await self.check_factual_accuracy(answer, topic)
-        
-        # Генерация персонализированной обратной связи
-        feedback = await self._generate_task19_feedback(
-            answer, score, result, topic
-        )
-        
-        return EvaluationResult(
-            scores={"Правильность примеров": score},
-            total_score=score,
-            max_score=3,
-            feedback=feedback,
-            detailed_analysis=result,
-            suggestions=result.get("suggestions", []),
-            factual_errors=factual_errors
-        )
+        async with self.ai_service:
+            result = await self.ai_service.get_json_completion(
+                evaluation_prompt,
+                system_prompt=self.get_system_prompt(),
+                temperature=0.2
+            )
+
+            if not result:
+                return self._get_fallback_result(answer, topic)
+
+            # Определение финального балла с учётом правил ЕГЭ 2025
+            score = self._calculate_final_score(result)
+
+            # Проверка фактических ошибок
+            factual_errors = await self.check_factual_accuracy(answer, topic)
+
+            # Генерация персонализированной обратной связи
+            feedback = await self._generate_task19_feedback(
+                answer, score, result, topic
+            )
+
+            return EvaluationResult(
+                scores={"Правильность примеров": score},
+                total_score=score,
+                max_score=3,
+                feedback=feedback,
+                detailed_analysis=result,
+                suggestions=result.get("suggestions", []),
+                factual_errors=factual_errors
+            )
     
     def _calculate_final_score(self, analysis: Dict[str, Any]) -> int:
         """Расчёт финального балла с учётом правил ЕГЭ 2025"""
@@ -245,13 +246,14 @@ class Task19AIEvaluator(BaseAIEvaluator):
 
 НЕ повторяй баллы и оценки - они уже показаны."""
         
-        result = await self.ai_service.get_completion(
-            prompt,
-            system_prompt=system_prompt,
-            temperature=0.7
-        )
-        
-        return result["text"] if result["success"] else ""
+        async with self.ai_service:
+            result = await self.ai_service.get_completion(
+                prompt,
+                system_prompt=system_prompt,
+                temperature=0.7
+            )
+
+            return result["text"] if result["success"] else ""
     
     def _get_fallback_result(self, answer: str, topic: str) -> EvaluationResult:
         """Простая оценка без AI"""

--- a/task24/ai_checker.py
+++ b/task24/ai_checker.py
@@ -55,22 +55,23 @@ class PlanAIChecker:
 - Корректность обществоведческих терминов
 - Наличие фактических ошибок"""
 
-        result = await self.ai_service.get_json_completion(
-            prompt,
-            system_prompt=system_prompt,
-            temperature=0.2
-        )
-        
-        if not result:
-            logger.error("Не удалось получить ответ от AI")
-            return {
-                "is_relevant": True,  # По умолчанию считаем релевантным
-                "confidence": 0.5,
-                "issues": [],
-                "suggestions": []
-            }
-        
-        return result
+        async with self.ai_service:
+            result = await self.ai_service.get_json_completion(
+                prompt,
+                system_prompt=system_prompt,
+                temperature=0.2
+            )
+
+            if not result:
+                logger.error("Не удалось получить ответ от AI")
+                return {
+                    "is_relevant": True,  # По умолчанию считаем релевантным
+                    "confidence": 0.5,
+                    "issues": [],
+                    "suggestions": []
+                }
+
+            return result
     
     async def check_subpoints_quality(
         self,
@@ -108,22 +109,23 @@ class PlanAIChecker:
 - Анализ каждого подпункта (subpoint_analysis: список)
 - Предложения по улучшению (improvement_suggestions: список строк)"""
 
-        result = await self.ai_service.get_json_completion(
-            prompt,
-            system_prompt=system_prompt,
-            temperature=0.2
-        )
-        
-        if not result:
-            # Возвращаем нейтральную оценку
-            return {
-                "relevant_count": len(subpoints),
-                "total_quality_score": 0.7,
-                "subpoint_analysis": [],
-                "improvement_suggestions": []
-            }
-        
-        return result
+        async with self.ai_service:
+            result = await self.ai_service.get_json_completion(
+                prompt,
+                system_prompt=system_prompt,
+                temperature=0.2
+            )
+
+            if not result:
+                # Возвращаем нейтральную оценку
+                return {
+                    "relevant_count": len(subpoints),
+                    "total_quality_score": 0.7,
+                    "subpoint_analysis": [],
+                    "improvement_suggestions": []
+                }
+
+            return result
     
     async def generate_personalized_feedback(
         self,
@@ -159,16 +161,17 @@ class PlanAIChecker:
 
 Не повторяй оценки и баллы - они уже показаны ученику."""
 
-        result = await self.ai_service.get_completion(
-            prompt,
-            system_prompt=system_prompt,
-            temperature=0.7  # Больше креативности для feedback
-        )
-        
-        if result["success"]:
-            return result["text"]
-        else:
-            return ""
+        async with self.ai_service:
+            result = await self.ai_service.get_completion(
+                prompt,
+                system_prompt=system_prompt,
+                temperature=0.7  # Больше креативности для feedback
+            )
+
+            if result["success"]:
+                return result["text"]
+            else:
+                return ""
     
     async def check_factual_errors(
         self,
@@ -201,16 +204,17 @@ class PlanAIChecker:
 - Фактические неточности
 - Логические противоречия"""
 
-        result = await self.ai_service.get_json_completion(
-            prompt,
-            system_prompt=system_prompt,
-            temperature=0.1  # Минимальная температура для точности
-        )
-        
-        if not result or not isinstance(result, list):
-            return []
-        
-        return result
+        async with self.ai_service:
+            result = await self.ai_service.get_json_completion(
+                prompt,
+                system_prompt=system_prompt,
+                temperature=0.1  # Минимальная температура для точности
+            )
+
+            if not result or not isinstance(result, list):
+                return []
+
+            return result
     
     def _format_etalon_points(self, points: List[Dict[str, Any]]) -> str:
         """Форматирование эталонных пунктов для промпта"""


### PR DESCRIPTION
## Summary
- open ai service using `async with` in evaluators and plan checker
- wrap all ai service calls within context managers
- keep plan evaluation flow unchanged while preventing runtime errors

## Testing
- `python test_task19.py`
- `python - <<'PY'
import asyncio
from core.ai_evaluator import Task19Evaluator
async def run():
    ev = Task19Evaluator()
    try:
        res = await ev.evaluate("пример 1\nпример 2\nпример 3", "Тема примеры")
        print('Result', res)
    except Exception as e:
        print('Error', e)
asyncio.run(run())
PY`
- `python - <<'PY'
import asyncio
from task24.ai_checker import PlanAIChecker
async def test():
    checker = PlanAIChecker()
    result = await checker.check_plan_relevance("1. пункт", "Тестовая тема", [])
    print(result)
asyncio.run(test())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68453ff4b538833184ccc82a94295295