### PR TITLE
Improve Task19 topic selection

### DIFF
--- a/task19/plugin.py
+++ b/task19/plugin.py
@@ -63,6 +63,8 @@ class Task19Plugin(BotPlugin):
                 ],
                 states.CHOOSING_BLOCK: [
                     CallbackQueryHandler(handlers.block_menu, pattern=r"^t19_block:"),
+                    CallbackQueryHandler(handlers.random_topic_block, pattern="^t19_random_block$"),
+                    CallbackQueryHandler(handlers.list_topics, pattern="^t19_list_topics$"),
                     CallbackQueryHandler(handlers.practice_mode, pattern="^t19_practice$"),
                     CallbackQueryHandler(handlers.return_to_menu, pattern="^t19_menu$"),
                     CallbackQueryHandler(handlers.select_block, pattern="^t19_select_block$"),


### PR DESCRIPTION
## Summary
- restructure task19 data loading to support blocks
- overhaul practice mode to offer block selection and random topic options
- add handlers to navigate blocks and topics with pagination
- register new handlers in plugin

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845937bfb1083319d42a8bb62a9539c