### PR TITLE
Fix task19 handler initialization

### DIFF
--- a/task19/handlers.py
+++ b/task19/handlers.py
@@ -27,7 +27,6 @@ logger = logging.getLogger(__name__)
 task19_data = {}
 
 # Инициализируем evaluator если еще не создан
-global evaluator
 if not evaluator:
     try:
         strictness_level = StrictnessLevel[os.getenv('TASK19_STRICTNESS', 'STRICT').upper()]


### PR DESCRIPTION
## Summary
- remove stray `global evaluator` statement from `task19/handlers.py`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684929d115648331bfba4666186a47cc