### PR TITLE
Enable asyncio tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -ra
+asyncio_mode = auto

--- a/test_task19.py
+++ b/test_task19.py
@@ -7,6 +7,7 @@ import asyncio
 import logging
 import sys
 import os
+import pytest
 
 # Добавляем корневую директорию в путь
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -16,6 +17,7 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 
+@pytest.mark.asyncio
 async def test_task19():
     """Тестирование компонентов task19"""
     


### PR DESCRIPTION
## Summary
- allow pytest to handle async tests via pytest-asyncio
- mark the task19 test as asyncio-aware

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68541ef5fe188331a4bebe41b0422a61