### PR TITLE
Define separate task25 FSM constants

### DIFF
--- a/core/states.py
+++ b/core/states.py
@@ -22,5 +22,5 @@ AWAITING_SEARCH = 22     # Ожидание поискового запроса
 AWAITING_FEEDBACK = 23     
 
 # Новые состояния для task25
-CHOOSING_BLOCK = 101  # Выбор блока тем
+CHOOSING_BLOCK_T25 = 101  # Выбор блока тем
 ANSWERING_PARTS = 102  # Ответ по частям

--- a/task25/handlers.py
+++ b/task25/handlers.py
@@ -13,7 +13,7 @@ from core import states
 from core.plugin_loader import build_main_menu
 
 # Добавьте этот импорт для состояния ANSWERING_PARTS
-from core.states import ANSWERING_PARTS
+from core.states import ANSWERING_PARTS, CHOOSING_BLOCK_T25
 
 logger = logging.getLogger(__name__)
 
@@ -479,7 +479,7 @@ async def block_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
         parse_mode=ParseMode.HTML
     )
     
-    return states.CHOOSING_BLOCK
+    return states.CHOOSING_BLOCK_T25
 
 
 def _build_topic_message(topic: Dict) -> str:
@@ -1491,7 +1491,7 @@ async def list_topics(update: Update, context: ContextTypes.DEFAULT_TYPE):
         parse_mode=ParseMode.HTML
     )
     
-    return states.CHOOSING_BLOCK
+    return states.CHOOSING_BLOCK_T25
 
 async def show_topic_by_id(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Показ конкретной темы по ID."""
@@ -2552,7 +2552,7 @@ async def handle_topic_by_block(update: Update, context: ContextTypes.DEFAULT_TY
         parse_mode=ParseMode.HTML
     )
     
-    return states.CHOOSING_BLOCK
+    return states.CHOOSING_BLOCK_T25
 
 
 async def handle_retry(update: Update, context: ContextTypes.DEFAULT_TYPE):

--- a/task25/plugin.py
+++ b/task25/plugin.py
@@ -8,13 +8,11 @@ from core import states
 from . import handlers
 
 # Импортируем константу ANSWERING_PARTS
-from core.states import ANSWERING_PARTS
+from core.states import ANSWERING_PARTS, CHOOSING_BLOCK_T25
 
 logger = logging.getLogger(__name__)
 
-# Добавляем новые состояния
-CHOOSING_BLOCK = 101
-ANSWERING_PARTS = 102
+# Добавляем новые состояния из core.states
 
 class Task25Plugin(BotPlugin):
     code = "task25"
@@ -109,7 +107,7 @@ class Task25Plugin(BotPlugin):
                     CallbackQueryHandler(handlers.return_to_menu, pattern="^t25_menu$"),
                 ],
                 
-                CHOOSING_BLOCK: [
+                CHOOSING_BLOCK_T25: [
                     CallbackQueryHandler(handlers.block_menu, pattern="^t25_block:"),
                     CallbackQueryHandler(handlers.show_topic_list, pattern="^t25_list_topics:"),
                     CallbackQueryHandler(handlers.random_topic_block, pattern="^t25_random_block$"),


### PR DESCRIPTION
## Summary
- define `CHOOSING_BLOCK_T25` in `core/states.py`
- reference the new state constant in `task25` plugin and handlers

## Testing
- `pytest -q` *(fails: fancycompleter missing LazyVersion)*

------
https://chatgpt.com/codex/tasks/task_e_68541ef43b0c8331af50bc76ed62956c