### PR TITLE
Fix admin IDs load in task24 initialization

### DIFF
--- a/task24/handlers.py
+++ b/task24/handlers.py
@@ -155,7 +155,7 @@ def init_data():
         plan_bot_data = PlanBotData({"plans": {}, "blocks": {}})
     
     # Загружаем список администраторов
-    load_admin_ids()
+    admin_manager._load_admin_ids()
     
     return data_loaded  # Возвращаем статус загрузки
 


### PR DESCRIPTION
## Summary
- call `admin_manager._load_admin_ids()` instead of undefined `load_admin_ids()` in `task24/handlers.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68545fc167308331aff0b3f7e54a2a91