### PR TITLE
Remove obsolete add-line comments

### DIFF
--- a/task19/handlers.py
+++ b/task19/handlers.py
@@ -200,7 +200,7 @@ async def entry_from_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
         [InlineKeyboardButton("📚 Теория и советы", callback_data="t19_theory")],
         [InlineKeyboardButton("🏦 Банк примеров", callback_data="t19_examples")],
         [InlineKeyboardButton("📊 Мой прогресс", callback_data="t19_progress")],
-        [InlineKeyboardButton("⚙️ Настройки", callback_data="t19_settings")],  # ДОБАВИТЬ ЭТУ СТРОКУ
+        [InlineKeyboardButton("⚙️ Настройки", callback_data="t19_settings")],
         [InlineKeyboardButton("🏠 Главное меню", callback_data="to_main_menu")]
     ])
     

--- a/task20/handlers.py
+++ b/task20/handlers.py
@@ -1703,7 +1703,7 @@ async def handle_answer(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Обработка ответа пользователя с AI-проверкой."""
     user_answer = update.message.text
     topic = context.user_data.get('current_topic')
-    user_id = update.effective_user.id  # ← ДОБАВИТЬ ЭТУ СТРОКУ ЗДЕСЬ
+    user_id = update.effective_user.id
     
     # Отладочное логирование
     logger.info(f"handle_answer called, evaluator = {evaluator}")


### PR DESCRIPTION
## Summary
- clean up leftover Russian comments instructing to add lines

## Testing
- `pytest -q` *(fails: fancycompleter has no attribute LazyVersion)*

------
https://chatgpt.com/codex/tasks/task_e_6855ab89440c8331ac1cd842dcd8e5d6