### PR TITLE
Fix streak notification

### DIFF
--- a/core/ui_helpers.py
+++ b/core/ui_helpers.py
@@ -86,8 +86,14 @@ async def show_streak_notification(update: Update, context: ContextTypes.DEFAULT
         
         # Автоудаление через 10 секунд
         if context.job_queue:
+            async def delete_msg(ctx: ContextTypes.DEFAULT_TYPE) -> None:
+                try:
+                    await msg.delete()
+                except Exception:
+                    pass
+
             context.job_queue.run_once(
-                lambda ctx: msg.delete(),
+                delete_msg,
                 when=10,
                 name=f"delete_streak_{msg.message_id}"
             )


### PR DESCRIPTION
## Summary
- use async callback when scheduling streak deletion

## Testing
- `pytest -q` *(fails: IndentationError in task19/handlers.py)*

------
https://chatgpt.com/codex/tasks/task_e_6855ab87634883319c02f985b5f978b7