### PR TITLE
Fix old component detection

### DIFF
--- a/unification_tester.py
+++ b/unification_tester.py
@@ -56,18 +56,26 @@ class UnificationTester:
         with open(filepath, 'r', encoding='utf-8') as f:
             content = f.read()
         
-        old_patterns = [
-            'UIComponents',
-            'EnhancedKeyboards',
+        # Используем регулярные выражения для точного совпадения названий
+        regex_patterns = [
+            ('UIComponents', re.compile(r'\bUIComponents\b')),
+            ('EnhancedKeyboards', re.compile(r'\bEnhancedKeyboards\b')),
+        ]
+
+        string_patterns = [
             'from .ui_components',
             'from .user_interface',
             '█' * 10,  # Старые прогресс-бары
             '▓' * 10,
         ]
-        
+
         found = []
-        for pattern in old_patterns:
-            if pattern in content and pattern != 'UniversalUIComponents':
+        for label, regex in regex_patterns:
+            if regex.search(content):
+                found.append(label)
+
+        for pattern in string_patterns:
+            if pattern in content:
                 found.append(pattern)
         
         return found


### PR DESCRIPTION
## Summary
- ensure old component names match exactly with regex word boundaries
- avoid false positives in unification tester

## Testing
- `pytest -q` *(fails: fancycompleter missing)*
- `python3 unification_tester.py`

------
https://chatgpt.com/codex/tasks/task_e_6855ab87dddc8331a032e91db6525d6d