### PR TITLE
Add streak_ok handler registration in task20 plugin

### DIFF
--- a/task20/plugin.py
+++ b/task20/plugin.py
@@ -131,6 +131,12 @@ class Task20Plugin(BotPlugin):
         
         # Регистрируем обработчики в приложении
         app.add_handler(conv_handler)
+        app.add_handler(
+            CallbackQueryHandler(
+                lambda u, c: u.callback_query.answer() if u.callback_query else None,
+                pattern="^streak_ok$",
+            )
+        )
         app.add_handler(CallbackQueryHandler(handlers.handle_achievement_ok, pattern="^t20_achievement_ok$"))
         logger.info(f"Registered handlers for {self.title} plugin")
 


### PR DESCRIPTION
## Summary
- register callback for streak achievements in task20

## Testing
- `pytest -q` *(fails: AttributeError: module 'fancycompleter' has no attribute 'LazyVersion')*

------
https://chatgpt.com/codex/tasks/task_e_685677df91348331a07bc6b6c97f6bdb