### PR TITLE
Prefix test_part callback constants

### DIFF
--- a/test_part/keyboards.py
+++ b/test_part/keyboards.py
@@ -136,24 +136,24 @@ def get_after_answer_keyboard(last_mode: str = "random") -> InlineKeyboardMarkup
     """Клавиатура после проверки ответа."""
     
     if last_mode == "topic":
-        main_button = InlineKeyboardButton("➡️ Ещё вопрос по теме", callback_data=CallbackData.NEXT_TOPIC)
+        main_button = InlineKeyboardButton("➡️ Ещё вопрос по теме", callback_data=CallbackData.TEST_NEXT_TOPIC)
     elif last_mode == "exam_num":
-        main_button = InlineKeyboardButton("➡️ Следующий номер", callback_data=CallbackData.NEXT_RANDOM)
+        main_button = InlineKeyboardButton("➡️ Следующий номер", callback_data=CallbackData.TEST_NEXT_RANDOM)
     else:  # random
-        main_button = InlineKeyboardButton("➡️ Ещё случайный", callback_data=CallbackData.NEXT_RANDOM)
+        main_button = InlineKeyboardButton("➡️ Ещё случайный", callback_data=CallbackData.TEST_NEXT_RANDOM)
 
     return InlineKeyboardMarkup([
         [main_button],
-        [InlineKeyboardButton("🔄 Сменить тему / режим", callback_data=CallbackData.CHANGE_TOPIC)],
-        [InlineKeyboardButton("🏠 Главное меню", callback_data=CallbackData.TO_MAIN_MENU)],
+        [InlineKeyboardButton("🔄 Сменить тему / режим", callback_data=CallbackData.TEST_CHANGE_TOPIC)],
+        [InlineKeyboardButton("🏠 Главное меню", callback_data=CallbackData.TEST_TO_MAIN_MENU)],
     ])
 
 def get_mistakes_nav_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup([
-        [InlineKeyboardButton("➡️ Следующая ошибка", callback_data=CallbackData.NEXT_MISTAKE)],
-        [InlineKeyboardButton("⏩ Пропустить", callback_data=CallbackData.SKIP_MISTAKE)],
-        [InlineKeyboardButton("🚪 Закончить разбор", callback_data=CallbackData.EXIT_MISTAKES)],
-        [InlineKeyboardButton("🏠 Главное меню", callback_data=CallbackData.TO_MAIN_MENU)],
+        [InlineKeyboardButton("➡️ Следующая ошибка", callback_data=CallbackData.TEST_NEXT_MISTAKE)],
+        [InlineKeyboardButton("⏩ Пропустить", callback_data=CallbackData.TEST_SKIP_MISTAKE)],
+        [InlineKeyboardButton("🚪 Закончить разбор", callback_data=CallbackData.TEST_EXIT_MISTAKES)],
+        [InlineKeyboardButton("🏠 Главное меню", callback_data=CallbackData.TEST_TO_MAIN_MENU)],
     ])
 
 def get_next_action_keyboard(last_mode: str, has_explanation: bool = False) -> InlineKeyboardMarkup:

--- a/test_part/utils.py
+++ b/test_part/utils.py
@@ -642,25 +642,25 @@ class TestPartCallbackData:
     """Стандартные callback_data для test_part плагина."""
     
     # Основные действия
-    TO_MAIN_MENU = "to_main_menu"
-    TO_MENU = "to_menu" 
-    CANCEL = "cancel"
+    TEST_TO_MAIN_MENU = "to_main_menu"
+    TEST_TO_MENU = "to_menu"
+    TEST_CANCEL = "cancel"
     
     # Навигация по режимам
-    MODE_RANDOM = "mode:random"
-    MODE_TOPIC = "mode:choose_topic"
-    MODE_EXAM_NUM = "mode:choose_exam_num"
+    TEST_MODE_RANDOM = "mode:random"
+    TEST_MODE_TOPIC = "mode:choose_topic"
+    TEST_MODE_EXAM_NUM = "mode:choose_exam_num"
     
     # Действия после ответа
-    NEXT_RANDOM = "next_random"
-    NEXT_TOPIC = "next_topic" 
-    CHANGE_TOPIC = "change_topic"
+    TEST_NEXT_RANDOM = "next_random"
+    TEST_NEXT_TOPIC = "next_topic"
+    TEST_CHANGE_TOPIC = "change_topic"
     
     # Работа с ошибками
-    SHOW_EXPLANATION = "show_explanation"
-    NEXT_MISTAKE = "next_mistake"
-    SKIP_MISTAKE = "skip_mistake"
-    EXIT_MISTAKES = "exit_mistakes"
+    TEST_SHOW_EXPLANATION = "show_explanation"
+    TEST_NEXT_MISTAKE = "next_mistake"
+    TEST_SKIP_MISTAKE = "skip_mistake"
+    TEST_EXIT_MISTAKES = "exit_mistakes"
     
     @classmethod
     def get_plugin_entry(cls, plugin_code: str) -> str:


### PR DESCRIPTION
## Summary
- rename callback constants in `test_part/utils.py` with `TEST_` prefix
- update keyboard callbacks accordingly

## Testing
- `pytest -q` *(fails: AttributeError: module 'fancycompleter' has no attribute 'LazyVersion')*
- `python3 unification_tester.py`

------
https://chatgpt.com/codex/tasks/task_e_685682328d048331a143626fc85a6747