### PR TITLE
Update callback scoring in unification tester

### DIFF
--- a/unification_tester.py
+++ b/unification_tester.py
@@ -151,11 +151,12 @@ class UnificationTester:
             
             # За стандартные callbacks
             if results['callbacks']:
-                std_ratio = len(results['callbacks']['standard']) / (
-                    len(results['callbacks']['standard']) + 
-                    len(results['callbacks']['non_standard']) + 0.1
-                )
-                score += int(std_ratio * 20)
+                total_callbacks = len(results['callbacks']['standard']) + len(results['callbacks']['non_standard'])
+                if total_callbacks:
+                    std_ratio = len(results['callbacks']['standard']) / total_callbacks
+                else:
+                    std_ratio = 1.0
+                score += round(std_ratio * 20)
             
             results['score'] = min(100, score)
         


### PR DESCRIPTION
## Summary
- update callback scoring logic to avoid dividing by zero

## Testing
- `python3 unification_tester.py`
- `pytest -q` *(fails: `fancycompleter` has no attribute `LazyVersion`)*

------
https://chatgpt.com/codex/tasks/task_e_68569261a9c8833188122214bd9f8e43