### PR TITLE
Improve exception logging

### DIFF
--- a/core/admin_tools.py
+++ b/core/admin_tools.py
@@ -91,8 +91,8 @@ class AdminManager:
                 with open(config_file, 'w') as f:
                     json.dump(example_config, f, indent=4)
                 logger.info(f"Created example admin config: {config_file}")
-            except:
-                pass
+            except Exception as e:
+                logger.error("Failed to create example admin config: %s", e)
     
     def is_admin(self, user_id: int) -> bool:
         """Проверка, является ли пользователь администратором."""
@@ -187,8 +187,8 @@ class AdminStats:
                                 dt = datetime.fromisoformat(timestamp)
                                 stats['daily_activity'][dt.date()] += 1
                                 stats['hourly_activity'][dt.hour] += 1
-                            except:
-                                pass
+                            except Exception as e:
+                                logger.error("Failed to parse timestamp in stats: %s", e)
             
             # Test Part статистика
             if 'mistakes' in user_data or 'correct_answers' in user_data:
@@ -439,8 +439,8 @@ async def export_all_data(update: Update, context: ContextTypes.DEFAULT_TYPE):
     # Удаляем старое сообщение
     try:
         await query.message.delete()
-    except:
-        pass
+    except Exception as e:
+        logger.error("Failed to delete export prompt message: %s", e)
     
     # Отправляем файл
     await query.message.reply_document(

--- a/core/document_processor.py
+++ b/core/document_processor.py
@@ -243,8 +243,8 @@ class DocumentHandlerMixin:
         # Удаляем сообщение о обработке
         try:
             await processing_msg.delete()
-        except:
-            pass
+        except Exception as e:
+            logger.error("Failed to delete processing message: %s", e)
         
         if not success:
             await update.message.reply_text(

--- a/core/ui_helpers.py
+++ b/core/ui_helpers.py
@@ -8,6 +8,9 @@ from typing import Dict, Optional
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, Message
 from telegram.constants import ParseMode
 from telegram.ext import ContextTypes
+import logging
+
+logger = logging.getLogger(__name__)
 
 async def show_thinking_animation(message: Message, text: str = "Анализирую") -> Message:
     """
@@ -28,9 +31,9 @@ async def show_thinking_animation(message: Message, text: str = "Анализи�
         for i in range(1, min(4, len(animations))):
             await asyncio.sleep(0.5)
             await thinking_msg.edit_text(f"{animations[i]} {text}...")
-    except:
-        # Игнорируем ошибки редактирования
-        pass
+    except Exception as e:
+        # Игнорируем ошибки редактирования, но логируем их
+        logger.error("Animation update failed: %s", e)
     
     return thinking_msg
 
@@ -256,7 +259,8 @@ def format_time_difference(timestamp: str) -> str:
             return f"{minutes} мин. назад"
         else:
             return "только что"
-    except:
+    except Exception as e:
+        logger.error("Failed to format timestamp: %s", e)
         return "недавно"
 
 def get_achievement_emoji(achievement_type: str) -> str:


### PR DESCRIPTION
## Summary
- add detailed exception logging in admin_tools
- log errors when removing processing messages
- include logger in ui_helpers and use explicit exception captures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68569ea479448331935518bd45fb596d