### PR TITLE
Add fallback error handling for task19 evaluation

### DIFF
--- a/task19/handlers.py
+++ b/task19/handlers.py
@@ -779,7 +779,12 @@ async def handle_answer(update: Update, context: ContextTypes.DEFAULT_TYPE):
             await show_streak_notification(update, context, 'correct', context.user_data['correct_streak'])
         
         return states.CHOOSING_MODE
-            
+
+    except Exception as e:
+        logger.error(f"Task19 evaluation error: {e}")
+        await update.message.reply_text("❌ Произошла ошибка при проверке. Попробуйте ещё раз.")
+        return states.CHOOSING_MODE
+
 
 async def handle_answer_document_task19(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Обработка примеров из документа для task19."""


### PR DESCRIPTION
## Summary
- handle unexpected errors in `handle_answer` for task19

## Testing
- `python -m py_compile task19/handlers.py`
- `pytest -q` *(fails: fancycompleter LazyVersion missing)*

------
https://chatgpt.com/codex/tasks/task_e_6857064ac90c8331a4ea99e840805879