### PR TITLE
Fix strictness handlers

### DIFF
--- a/task19/handlers.py
+++ b/task19/handlers.py
@@ -50,14 +50,14 @@ if not evaluator:
         evaluator = None
 
 
-# Добавить команду для изменения уровня строгости (опционально)
-async def set_strictness(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Установка уровня строгости проверки (только для админов)."""
+# Меню выбора уровня строгости (только для админов)
+async def strictness_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Показывает меню выбора уровня строгости проверки."""
     query = update.callback_query
     await query.answer()
-    
+
     # Проверка прав (добавьте свою логику проверки админов)
-    if not admin_manager.is_admin(user_id):
+    if not admin_manager.is_admin(query.from_user.id):
         await query.answer("⛔ Только для администраторов", show_alert=True)
         return
     
@@ -82,27 +82,6 @@ async def set_strictness(update: Update, context: ContextTypes.DEFAULT_TYPE):
     )
 
 
-async def apply_strictness(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Применение выбранного уровня строгости."""
-    global evaluator
-    
-    query = update.callback_query
-    await query.answer()
-    
-    level_str = query.data.split(":")[1].upper()
-    
-    try:
-        new_level = StrictnessLevel[level_str]
-        evaluator = Task19AIEvaluator(strictness=new_level)
-        
-        await query.answer(f"✅ Установлен уровень: {new_level.value}", show_alert=True)
-        
-        # Возвращаемся в меню
-        return await return_to_menu(update, context)
-        
-    except Exception as e:
-        logger.error(f"Error setting strictness: {e}")
-        await query.answer("❌ Ошибка изменения настроек", show_alert=True)
 
 async def delete_previous_messages(context: ContextTypes.DEFAULT_TYPE, chat_id: int, keep_message_id: Optional[int] = None):
     """Удаляет предыдущие сообщения диалога (включая сообщения пользователя)."""
@@ -1713,8 +1692,8 @@ async def settings_mode(update: Update, context: ContextTypes.DEFAULT_TYPE):
     return states.CHOOSING_MODE
 
 
-async def set_strictness(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Установка уровня строгости."""
+async def apply_strictness(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Установка выбранного уровня строгости."""
     global evaluator
     
     query = update.callback_query

--- a/task19/plugin.py
+++ b/task19/plugin.py
@@ -71,7 +71,7 @@ class Task19Plugin(BotPlugin):
                     CallbackQueryHandler(handlers.bank_search, pattern="^t19_bank_search$"),
                     
                     # Настройки
-                    CallbackQueryHandler(handlers.set_strictness, pattern="^t19_set_strictness:"),
+                    CallbackQueryHandler(handlers.apply_strictness, pattern="^t19_set_strictness:"),
                     
                     # Статистика
                     CallbackQueryHandler(handlers.detailed_progress, pattern="^t19_detailed_progress$"),

--- a/test_strictness_menu.py
+++ b/test_strictness_menu.py
@@ -1,0 +1,29 @@
+import pytest
+from task19 import handlers
+from core.admin_tools import admin_manager
+
+class DummyQuery:
+    def __init__(self):
+        self.from_user = type('User', (), {'id': 1})()
+    async def answer(self, *args, **kwargs):
+        pass
+    async def edit_message_text(self, *args, **kwargs):
+        pass
+
+class DummyUpdate:
+    def __init__(self):
+        self.callback_query = DummyQuery()
+
+class DummyContext:
+    pass
+
+@pytest.mark.asyncio
+async def test_strictness_menu_no_nameerror(monkeypatch):
+    monkeypatch.setattr(admin_manager, "is_admin", lambda uid: True)
+    update = DummyUpdate()
+    context = DummyContext()
+    try:
+        await handlers.strictness_menu(update, context)
+    except NameError as e:
+        pytest.fail(f"strictness_menu raised NameError: {e}")
+


### PR DESCRIPTION
## Summary
- fix admin check for strictness menu
- remove duplicate `set_strictness` and split into `strictness_menu` and `apply_strictness`
- update plugin registration
- add regression test for strictness menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857d8c3c5b48331aaf0917a425e1781