### PR TITLE
Add graceful database shutdown

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -26,6 +26,10 @@ async def post_init(application: Application) -> None:
     
     logger.info("Инициализация завершена")
 
+async def post_shutdown(application: Application) -> None:
+    """Выполняется при завершении приложения."""
+    await db.close_db()
+
 async def start(update, context):
     """Главная команда /start."""
     await update.message.reply_text(
@@ -45,6 +49,7 @@ def main():
         Application.builder()
         .token(BOT_TOKEN)
         .post_init(post_init)
+        .post_shutdown(post_shutdown)
         .build()
     )
 

--- a/core/db.py
+++ b/core/db.py
@@ -31,6 +31,13 @@ async def get_db() -> aiosqlite.Connection:
         _db = await aiosqlite.connect(DATABASE_FILE)
     return _db
 
+async def close_db() -> None:
+    """Закрывает глобальное подключение к базе данных, если оно открыто."""
+    global _db
+    if _db is not None:
+        await _db.close()
+        _db = None
+
 async def update_daily_streak(user_id: int) -> Tuple[int, int]:
     """
     Обновляет ДНЕВНОЙ стрик пользователя на основе последней активности.

--- a/test_db_connection.py
+++ b/test_db_connection.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import pytest
+
+# Ensure project root is in path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# Provide dummy token to satisfy config import
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "dummy")
+
+from core import db
+
+@pytest.mark.asyncio
+async def test_open_and_close_db():
+    conn = await db.get_db()
+    assert conn is not None
+    await db.close_db()
+    assert db._db is None


### PR DESCRIPTION
## Summary
- add `close_db` in `core/db.py`
- clean up the DB connection at application shutdown
- test opening and closing the DB connection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857d8c4c75c833192a7caeef5db48bc