### PR TITLE
Fix quote cleaning in document processor

### DIFF
--- a/core/document_processor.py
+++ b/core/document_processor.py
@@ -198,8 +198,17 @@ class DocumentProcessor:
         text = re.sub(r'[\x00-\x08\x0B-\x0C\x0E-\x1F\x7F]', '', text)
         
         # Нормализуем кавычки
-        text = text.replace('"', '"').replace('"', '"')
-        text = text.replace(''', "'").replace(''', "'")
+        quote_map = {
+            "“": '"',
+            "”": '"',
+            "„": '"',
+            "«": '"',
+            "»": '"',
+            "‘": "'",
+            "’": "'",
+            "‚": "'",
+        }
+        text = text.translate(str.maketrans(quote_map))
         
         return text.strip()
 

--- a/tests/test_document_processor.py
+++ b/tests/test_document_processor.py
@@ -1,0 +1,8 @@
+import pytest
+from core.document_processor import DocumentProcessor
+
+
+def test_clean_text_removes_noise_and_normalizes_quotes():
+    raw = "  “Test”\n\n\t  text ‘example’  "
+    cleaned = DocumentProcessor._clean_text(raw)
+    assert cleaned == '"Test" text \'example\''


### PR DESCRIPTION
## Summary
- fix quote normalization in `_clean_text`
- add tests for `_clean_text` to check quote conversion and whitespace cleanup

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -p no:debugging -q`


------
https://chatgpt.com/codex/tasks/task_e_6857d8c605808331ac9b909426d6cf00