### PR TITLE
Fix error_handler missing states import

### DIFF
--- a/core/error_handler.py
+++ b/core/error_handler.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 
 from telegram import Update, InlineKeyboardMarkup, InlineKeyboardButton
 from telegram.ext import ContextTypes, ConversationHandler
+from core import states
 from telegram.error import BadRequest, NetworkError, TimedOut
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- import `states` in `core/error_handler`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'get_admin_keyboard_extension')*

------
https://chatgpt.com/codex/tasks/task_e_68585004cea883318d00517922576540