### PR TITLE
Fix cyclic imports by centralizing type definitions

### DIFF
--- a/task19/evaluator.py
+++ b/task19/evaluator.py
@@ -5,42 +5,29 @@ import os
 import json
 from enum import Enum
 from typing import Dict, List, Any, Optional
-from dataclasses import dataclass
 # Вместо импорта типов из других модулей
-from core.types import UserID, TaskType, EvaluationResult, CallbackData
+from core.types import (
+    UserID,
+    TaskType,
+    EvaluationResult,
+    CallbackData,
+    TaskRequirements,
+)
 logger = logging.getLogger(__name__)
 
 # Безопасный импорт
 try:
     from core.ai_evaluator import (
         BaseAIEvaluator,
-        TaskRequirements,
     )
     from core.ai_service import YandexGPTService, YandexGPTConfig, YandexGPTModel
     AI_EVALUATOR_AVAILABLE = True
 except ImportError as e:
     logger.warning(f"AI evaluator components not available: {e}")
     AI_EVALUATOR_AVAILABLE = False
-    
+
     # Заглушки для работы без AI
-    @dataclass
-    class TaskRequirements:
-        task_number: int
-        task_name: str
-        max_score: int
-        criteria: List[Dict]
-        description: str
-    
-    @dataclass
-    class EvaluationResult:
-        scores: Dict[str, int]
-        total_score: int
-        max_score: int
-        feedback: str
-        detailed_analysis: Optional[Dict] = None
-        suggestions: Optional[List[str]] = None
-        factual_errors: Optional[List[str]] = None
-    
+
     class BaseAIEvaluator:
         def __init__(self, requirements: TaskRequirements):
             self.requirements = requirements

--- a/task20/evaluator.py
+++ b/task20/evaluator.py
@@ -5,7 +5,13 @@ import os
 import json
 from enum import Enum
 from typing import Dict, List, Any, Optional
-from dataclasses import dataclass
+from core.types import (
+    UserID,
+    TaskType,
+    EvaluationResult,
+    CallbackData,
+    TaskRequirements,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -13,34 +19,15 @@ logger = logging.getLogger(__name__)
 try:
     from core.ai_evaluator import (
         BaseAIEvaluator,
-        EvaluationResult,
-        TaskRequirements,
     )
     from core.ai_service import YandexGPTService, YandexGPTConfig, YandexGPTModel
     AI_EVALUATOR_AVAILABLE = True
 except ImportError as e:
     logger.warning(f"AI evaluator components not available: {e}")
     AI_EVALUATOR_AVAILABLE = False
-    
+
     # Заглушки для работы без AI
-    @dataclass
-    class TaskRequirements:
-        task_number: int
-        task_name: str
-        max_score: int
-        criteria: List[Dict]
-        description: str
-    
-    @dataclass
-    class EvaluationResult:
-        scores: Dict[str, int]
-        total_score: int
-        max_score: int
-        feedback: str
-        detailed_analysis: Optional[Dict] = None
-        suggestions: Optional[List[str]] = None
-        factual_errors: Optional[List[str]] = None
-    
+
     class BaseAIEvaluator:
         def __init__(self, requirements: TaskRequirements):
             self.requirements = requirements

--- a/task25/evaluator.py
+++ b/task25/evaluator.py
@@ -5,7 +5,13 @@ import os
 import json
 from enum import Enum
 from typing import Dict, List, Any, Optional
-from dataclasses import dataclass
+from core.types import (
+    UserID,
+    TaskType,
+    EvaluationResult,
+    CallbackData,
+    TaskRequirements,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -13,8 +19,6 @@ logger = logging.getLogger(__name__)
 try:
     from core.ai_evaluator import (
         BaseAIEvaluator,
-        EvaluationResult,
-        TaskRequirements,
     )
     # ВАЖНО: Импортируем YandexGPTModel из core.ai_service
     from core.ai_service import YandexGPTService, YandexGPTConfig, YandexGPTModel
@@ -22,26 +26,9 @@ try:
 except ImportError as e:
     logger.warning(f"AI evaluator components not available: {e}")
     AI_EVALUATOR_AVAILABLE = False
-    
+
     # Заглушки для работы без AI
-    @dataclass
-    class TaskRequirements:
-        task_number: int
-        task_name: str
-        max_score: int
-        criteria: List[Dict]
-        description: str
-    
-    @dataclass
-    class EvaluationResult:
-        scores: Dict[str, int]
-        total_score: int
-        max_score: int
-        feedback: str
-        detailed_analysis: Optional[Dict] = None
-        suggestions: Optional[List[str]] = None
-        factual_errors: Optional[List[str]] = None
-    
+
     class BaseAIEvaluator:
         def __init__(self, requirements: TaskRequirements):
             self.requirements = requirements


### PR DESCRIPTION
## Summary
- import common types from `core.types`
- remove duplicated `EvaluationResult` definitions in task evaluators

## Testing
- `pytest -q` *(fails: module 'fancycompleter' has no attribute 'LazyVersion')*

------
https://chatgpt.com/codex/tasks/task_e_685920acd38c8331961167964f7fcf00