### PR TITLE
Add missing handlers for test_part callbacks

### DIFF
--- a/test_part/handlers.py
+++ b/test_part/handlers.py
@@ -18,6 +18,12 @@ from core.universal_ui import (AdaptiveKeyboards, MessageFormatter,
 from core.error_handler import safe_handler, auto_answer_callback
 from . import keyboards, utils
 from .loader import AVAILABLE_BLOCKS, QUESTIONS_DATA, QUESTIONS_DICT_FLAT
+from .missing_handlers import (
+    detailed_report,
+    export_csv,
+    work_mistakes,
+    check_subscription,
+)
 
 try:
     from .cache import questions_cache

--- a/test_part/plugin.py
+++ b/test_part/plugin.py
@@ -238,10 +238,26 @@ class TestPartPlugin(BotPlugin):
         app.add_handler(CommandHandler("report", handlers.cmd_report), group=3)
 
         # Callback handlers for статистика и подписка
-        app.add_handler(CallbackQueryHandler(handlers.handle_detailed_report, pattern="^detailed_report$"), group=3)
-        app.add_handler(CallbackQueryHandler(handlers.handle_export_csv, pattern="^export_csv$"), group=3)
-        app.add_handler(CallbackQueryHandler(handlers.handle_work_mistakes, pattern="^work_mistakes$"), group=3)
-        app.add_handler(CallbackQueryHandler(handlers.handle_check_subscription, pattern="^check_subscription$"), group=3)
+        app.add_handler(
+            CallbackQueryHandler(
+                handlers.detailed_report, pattern="^detailed_report$"
+            ),
+            group=3,
+        )
+        app.add_handler(
+            CallbackQueryHandler(handlers.export_csv, pattern="^export_csv$"),
+            group=3,
+        )
+        app.add_handler(
+            CallbackQueryHandler(handlers.work_mistakes, pattern="^work_mistakes$"),
+            group=3,
+        )
+        app.add_handler(
+            CallbackQueryHandler(
+                handlers.check_subscription, pattern="^check_subscription$"
+            ),
+            group=3,
+        )
         
         # Команда отладки (только для разработки)
         app.add_handler(CommandHandler("debug_streaks", handlers.cmd_debug_streaks), group=3)


### PR DESCRIPTION
## Summary
- import new handlers from `missing_handlers` into `handlers`
- register callback handlers for progress-related features in plugin

## Testing
- `pytest -q` *(fails: module fancycompleter has no attribute LazyVersion)*

------
https://chatgpt.com/codex/tasks/task_e_685920c3e858833198c00ad0c81320aa