### PR TITLE
Fix duplicate traceback logs

### DIFF
--- a/core/error_handler.py
+++ b/core/error_handler.py
@@ -124,9 +124,9 @@ def safe_handler(
             except Exception as e:
                 # Неизвестные ошибки
                 if log_errors:
+                    # logger.exception already logs the traceback
                     logger.exception(
-                        f"Unexpected error in {handler_name} for user {user_id}: {e}\n"
-                        f"Traceback: {traceback.format_exc()}"
+                        f"Unexpected error in {handler_name} for user {user_id}: {e}"
                     )
                 
                 # Сохраняем информацию об ошибке для админов


### PR DESCRIPTION
## Summary
- avoid logging traceback twice in `safe_handler`

## Testing
- `python test_fixes.py`


------
https://chatgpt.com/codex/tasks/task_e_685931dab36483318734c6c27de09da1