### PR TITLE
Add Task19 handler registration

### DIFF
--- a/task19/handlers.py
+++ b/task19/handlers.py
@@ -590,62 +590,6 @@ async def show_progress_enhanced(update: Update, context: ContextTypes.DEFAULT_T
     return states.CHOOSING_MODE
 
 @safe_handler()
-async def choose_topic(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Обработка выбора темы."""
-    query = update.callback_query
-    
-    # Удаляем все предыдущие сообщения перед показом нового задания
-    await delete_previous_messages(context, query.message.chat_id)
-    
-    if query.data == "t19_random":
-        topic = random.choice(task19_data['topics'])
-    else:
-        topic_id = int(query.data.split(':')[1])
-        topic = next((t for t in task19_data['topics'] if t['id'] == topic_id), None)
-    
-    if not topic:
-        await query.message.chat.send_message(
-            "❌ Тема не найдена",
-            reply_markup=InlineKeyboardMarkup([[
-                InlineKeyboardButton("⬅️ Назад", callback_data="t19_practice")
-            ]])
-        )
-        return states.CHOOSING_MODE
-    
-    # Сохраняем текущую тему
-    context.user_data['current_topic'] = topic
-    
-    text = f"""📝 <b>Задание 19</b>
-
-<b>Тема:</b> {topic['title']}
-
-<b>Задание:</b> {topic['task_text']}
-
-<b>Требования:</b>
-• Приведите три примера
-• Каждый пример должен быть конкретным
-• Избегайте абстрактных формулировок
-• Указывайте детали (имена, даты, места)
-
-💡 <i>Отправьте ваш ответ одним сообщением</i>"""
-    
-    kb = InlineKeyboardMarkup([[
-        InlineKeyboardButton("⬅️ Выбрать другую тему", callback_data="t19_practice")
-    ]])
-    
-    # Отправляем новое сообщение
-    sent_msg = await query.message.chat.send_message(
-        text,
-        reply_markup=kb,
-        parse_mode=ParseMode.HTML
-    )
-    
-    # Сохраняем ID сообщения с заданием
-    context.user_data['task19_question_msg_id'] = sent_msg.message_id
-    
-    return states.ANSWERING
-
-@safe_handler()
 async def handle_answer(update: Update, context: ContextTypes.DEFAULT_TYPE):
     return await safe_handle_answer_task19(update, context)
 
@@ -822,73 +766,6 @@ async def bank_navigation(update: Update, context: ContextTypes.DEFAULT_TYPE):
     return states.CHOOSING_MODE
 
 
-@safe_handler()
-async def my_progress(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Показ прогресса пользователя."""
-    query = update.callback_query
-    
-    results = context.user_data.get('task19_results', [])
-    
-    if not results:
-        text = MessageFormatter.format_welcome_message(
-            "задание 19", 
-            is_new_user=True
-        )
-        kb = InlineKeyboardMarkup([[
-            InlineKeyboardButton("💪 Начать практику", callback_data="t19_practice"),
-            InlineKeyboardButton("⬅️ Назад", callback_data="t19_menu")
-        ]])
-    else:
-        # Собираем статистику
-        total_attempts = len(results)
-        total_score = sum(r['score'] for r in results)
-        max_possible = sum(r['max_score'] for r in results)
-        avg_score = total_score / total_attempts
-        
-        # Анализ по темам для топ результатов
-        topic_stats = {}
-        for result in results:
-            topic = result['topic']
-            if topic not in topic_stats:
-                topic_stats[topic] = []
-            topic_stats[topic].append(result['score'])
-        
-        # Топ темы
-        top_results = []
-        for topic, scores in topic_stats.items():
-            avg = sum(scores) / len(scores)
-            top_results.append({
-                'topic': topic,
-                'score': avg,
-                'max_score': 3
-            })
-        top_results.sort(key=lambda x: x['score'], reverse=True)
-        
-        # Форматируем сообщение универсальным способом
-        text = MessageFormatter.format_progress_message({
-            'total_attempts': total_attempts,
-            'average_score': avg_score,
-            'completed': len(topic_stats),
-            'total': 50,  # Предполагаем 50 тем
-            'total_time': 0,  # Можно добавить подсчет времени
-            'top_results': top_results[:3],
-            'current_average': avg_score * 33.33,
-            'previous_average': (avg_score * 33.33) - 5
-        }, "заданию 19")
-        
-        # Адаптивная клавиатура
-        kb = AdaptiveKeyboards.create_progress_keyboard(
-            has_detailed_stats=True,
-            can_export=True,
-            module_code="t19"
-        )
-    
-    await query.edit_message_text(
-        text,
-        reply_markup=kb,
-        parse_mode=ParseMode.HTML
-    )
-    return states.CHOOSING_MODE
 
 
 @safe_handler()
@@ -985,7 +862,7 @@ async def handle_result_action(update: Update, context: ContextTypes.DEFAULT_TYP
     
     elif query.data == "t19_progress":
         # Показываем прогресс (не удаляем сообщения)
-        return await my_progress(update, context)
+        return await show_progress_enhanced(update, context)
 
 async def cmd_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Отмена текущего действия."""
@@ -1038,64 +915,6 @@ async def reset_results(update: Update, context: ContextTypes.DEFAULT_TYPE):
         return states.CHOOSING_MODE
 
 
-
-@safe_handler()
-async def my_progress(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    query = update.callback_query
-    
-    results = context.user_data.get('task19_results', [])
-    
-    if not results:
-        text = "📊 <b>Ваш прогресс</b>\n\nВы еще не решали задания."
-        kb = InlineKeyboardMarkup([[
-            InlineKeyboardButton("⬅️ Назад", callback_data="t19_menu")
-        ]])
-    else:
-        total_attempts = len(results)
-        total_score = sum(r['score'] for r in results)
-        max_possible = sum(r['max_score'] for r in results)
-        avg_score = total_score / total_attempts
-        
-        # Визуальный прогресс-бар
-        progress_percent = int(total_score / max_possible * 100) if max_possible > 0 else 0
-        filled = "█" * (progress_percent // 10)
-        empty = "░" * (10 - progress_percent // 10)
-        progress_bar = f"{filled}{empty}"
-        
-        text = f"""📊 <b>Ваш прогресс по заданию 19</b>
-
-📈 Прогресс: {progress_bar} {progress_percent}%
-📝 Решено заданий: {total_attempts}
-⭐ Средний балл: {avg_score:.1f}/3
-🏆 Общий результат: {total_score}/{max_possible}
-
-<b>Последние попытки:</b>"""
-        
-        for result in results[-5:]:
-            score_emoji = "🟢" if result['score'] == 3 else "🟡" if result['score'] >= 2 else "🔴"
-            text += f"\n{score_emoji} {result['topic']}: {result['score']}/3"
-        
-        # Рекомендации
-        if avg_score < 2:
-            text += "\n\n💡 <b>Совет:</b> Изучите теорию и примеры эталонных ответов."
-        elif avg_score < 2.5:
-            text += "\n\n💡 <b>Совет:</b> Обратите внимание на конкретизацию примеров."
-        else:
-            text += "\n\n🎉 <b>Отлично!</b> Вы хорошо справляетесь с заданием 19!"
-        
-        kb = InlineKeyboardMarkup([
-            [InlineKeyboardButton("📊 Детальная статистика", callback_data="t19_detailed_progress")],
-            [InlineKeyboardButton("📤 Экспорт результатов", callback_data="t19_export")],
-            [InlineKeyboardButton("🔄 Сбросить результаты", callback_data="t19_reset_confirm")],
-            [InlineKeyboardButton("⬅️ Назад", callback_data="t19_menu")]
-        ])
-    
-    await query.edit_message_text(
-        text,
-        reply_markup=kb,
-        parse_mode=ParseMode.HTML
-    )
-    return states.CHOOSING_MODE
 
 async def cmd_task19_settings(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Команда /task19_settings для быстрого доступа к настройкам."""

--- a/task19/plugin.py
+++ b/task19/plugin.py
@@ -43,6 +43,7 @@ class Task19Plugin(BotPlugin):
                     pattern=f"^choose_{self.code}$"
                 ),
                 CommandHandler("task19", handlers.cmd_task19),
+                CommandHandler("task19_settings", handlers.cmd_task19_settings),
             ],
             states={
                 states.CHOOSING_MODE: [
@@ -50,10 +51,14 @@ class Task19Plugin(BotPlugin):
                     CallbackQueryHandler(handlers.practice_mode, pattern="^t19_practice$"),
                     CallbackQueryHandler(handlers.theory_mode, pattern="^t19_theory$"),
                     CallbackQueryHandler(handlers.examples_bank, pattern="^t19_examples$"),
-                    CallbackQueryHandler(handlers.my_progress, pattern="^t19_progress$"),
+                    CallbackQueryHandler(handlers.show_progress_enhanced, pattern="^t19_progress$"),
                     CallbackQueryHandler(handlers.settings_mode, pattern="^t19_settings$"),
+                    CallbackQueryHandler(handlers.strictness_menu, pattern="^t19_strictness_menu$"),
                     CallbackQueryHandler(handlers.back_to_main_menu, pattern="^to_main_menu$"),
                     CallbackQueryHandler(handlers.noop, pattern="^noop$"),
+
+                    # Дополнительные действия
+                    CallbackQueryHandler(handlers.reset_results, pattern="^t19_reset_confirm$"),
                     
                     # Обработчики для выбора тем
                     CallbackQueryHandler(handlers.select_block, pattern="^t19_select_block$"),
@@ -81,7 +86,6 @@ class Task19Plugin(BotPlugin):
                     CallbackQueryHandler(handlers.handle_theory_sections, pattern="^t19_(how_to_write|good_examples|common_mistakes|useful_phrases)$"),
                     
                     # Настройки
-                    CallbackQueryHandler(handlers.handle_settings_actions, pattern="^t19_(reset_progress|confirm_reset)$"),
                     
                     # Новые функции
                     CallbackQueryHandler(handlers.mistakes_mode, pattern="^t19_mistakes$"),
@@ -97,7 +101,7 @@ class Task19Plugin(BotPlugin):
                 ],
                 
                 states.CHOOSING_TOPIC: [
-                    CallbackQueryHandler(handlers.choose_topic, pattern="^t19_topic:"),
+                    CallbackQueryHandler(handlers.select_topic, pattern="^t19_topic:"),
                     CallbackQueryHandler(handlers.practice_mode, pattern="^t19_practice$"),
                     CallbackQueryHandler(handlers.block_menu, pattern="^t19_block:"),
                     CallbackQueryHandler(handlers.select_block, pattern="^t19_select_block$"),
@@ -108,6 +112,9 @@ class Task19Plugin(BotPlugin):
                     MessageHandler(filters.TEXT & ~filters.COMMAND, handlers.handle_answer),
                     MessageHandler(filters.Document.ALL, handlers.handle_answer_document_task19),
                     CallbackQueryHandler(handlers.practice_mode, pattern="^t19_practice$"),
+                ],
+                states.SEARCHING: [
+                    MessageHandler(filters.TEXT & ~filters.COMMAND, handlers.handle_bank_search),
                 ],
                 states.AWAITING_FEEDBACK: [
                     CallbackQueryHandler(handlers.practice_mode, pattern="^next_topic$"),


### PR DESCRIPTION
## Summary
- register more handlers for task19 plugin
- clean up unused handlers
- add strictness and progress commands

## Testing
- `python test_task19.py`
- `python test_strictness_menu.py`


------
https://chatgpt.com/codex/tasks/task_e_68593f9130008331ba979371eace6b06