### PR TITLE
Add retry handler mapping for task24

### DIFF
--- a/task24/plugin.py
+++ b/task24/plugin.py
@@ -69,6 +69,12 @@ class Task24Plugin(BotPlugin):
                     MessageHandler(filters.TEXT & ~filters.COMMAND, handlers.handle_plan_enhanced),
                     MessageHandler(filters.Document.ALL, handlers.handle_plan_document),
                 ],
+                states.AWAITING_FEEDBACK: [
+                    CallbackQueryHandler(handlers.t24_retry, pattern="^t24_retry$"),
+                    CallbackQueryHandler(handlers.next_topic, pattern="^next_topic$"),
+                    CallbackQueryHandler(handlers.back_to_menu, pattern="^t24_menu$"),
+                    CallbackQueryHandler(handlers.back_to_main_menu, pattern="^to_main_menu$"),
+                ],
                 states.AWAITING_SEARCH: [
                     MessageHandler(filters.TEXT & ~filters.COMMAND, handlers.handle_search_query),
                 ],


### PR DESCRIPTION
## Summary
- include `t24_retry` callback in conversation states
- map retry handler under `AWAITING_FEEDBACK`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68593f9304d08331bbdbb8b92cc4b958